### PR TITLE
Add missingType.generics to PHPStan ignored errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,4 @@ parameters:
 		- %rootDir%/../../../tests/bootstrap.php
 	ignoreErrors:
 		- identifier: missingType.iterableValue
+		- identifier: missingType.generics


### PR DESCRIPTION
## Summary
- CakePHP's `View` class now declares a `@template TSubject` generic type, causing PHPStan `missingType.generics` errors when `View` is used as a parameter type without specifying the generic
- Added `missingType.generics` to the ignored errors in `phpstan.neon`, consistent with the existing `missingType.iterableValue` ignore