### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/src/View/Helper/MetaHelper.php
+++ b/src/View/Helper/MetaHelper.php
@@ -112,7 +112,7 @@ class MetaHelper extends Helper {
 			if ($controller && $action) {
 				$controllerName = Inflector::humanize(Inflector::underscore($controller));
 				$actionName = Inflector::humanize(Inflector::underscore($action));
-				$this->meta['title'] = __($controllerName) . ' - ' . __($actionName);
+				$this->meta['title'] = __d('meta', $controllerName) . ' - ' . __d('meta', $actionName);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Convert the 2 `__()` calls in `MetaHelper::_title()` to `__d('meta', ...)` so the dynamic title lookups (controller/action names) live in the plugin's own domain instead of the host app's `default` domain.
- No `resources/locales/meta.pot` is shipped: the only translation calls in this plugin take dynamic `$controllerName` / `$actionName` arguments (they look up whatever the host app's controller/action names are at runtime), so there is nothing for `bin/cake i18n extract` to capture into a static POT. Translators populate a `meta.po` by hand from their own controller/action set.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 34 / 34
- phpstan: no errors
- phpcs: clean