### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/View/Helper/MetaHelper.php
+++ b/src/View/Helper/MetaHelper.php
@@ -528,7 +528,7 @@ class MetaHelper extends Helper {
 			$url = $this->getView()->getRequest()->getAttribute('here');
 		} elseif (is_array($url)) {
 			$url = $this->Url->build($url, $options);
-		} elseif (!preg_match('/^([a-z][a-z0-9+\-.]*:)?\/\//', (string) $url)) {
+		} elseif (!preg_match('/^([a-z][a-z0-9+\-.]*:)?\/\//', (string)$url)) {
 			$url = $this->Url->build($url, $options);
 		}
 
@@ -623,11 +623,11 @@ class MetaHelper extends Helper {
 		];
 
 		if (isset($data['author'])) {
-            $article['author'] = is_string($data['author']) ? [
-					'@type' => 'Person',
-					'name' => $data['author'],
-				] : $data['author'];
-        }
+			$article['author'] = is_string($data['author']) ? [
+				'@type' => 'Person',
+				'name' => $data['author'],
+			] : $data['author'];
+		}
 
 		if (isset($data['datePublished'])) {
 			$article['datePublished'] = $data['datePublished'];

--- a/src/View/Helper/MetaHelper.php
+++ b/src/View/Helper/MetaHelper.php
@@ -130,7 +130,7 @@ class MetaHelper extends Helper {
 			return null;
 		}
 
-		if (strpos($locale, '_') !== false) {
+		if (str_contains($locale, '_')) {
 			$locale = str_replace('_', '-', $locale);
 		}
 
@@ -528,7 +528,7 @@ class MetaHelper extends Helper {
 			$url = $this->getView()->getRequest()->getAttribute('here');
 		} elseif (is_array($url)) {
 			$url = $this->Url->build($url, $options);
-		} elseif (!preg_match('/^([a-z][a-z0-9+\-.]*:)?\/\//', $url)) {
+		} elseif (!preg_match('/^([a-z][a-z0-9+\-.]*:)?\/\//', (string) $url)) {
 			$url = $this->Url->build($url, $options);
 		}
 
@@ -623,15 +623,11 @@ class MetaHelper extends Helper {
 		];
 
 		if (isset($data['author'])) {
-			if (is_string($data['author'])) {
-				$article['author'] = [
+            $article['author'] = is_string($data['author']) ? [
 					'@type' => 'Person',
 					'name' => $data['author'],
-				];
-			} else {
-				$article['author'] = $data['author'];
-			}
-		}
+				] : $data['author'];
+        }
 
 		if (isset($data['datePublished'])) {
 			$article['datePublished'] = $data['datePublished'];
@@ -868,7 +864,7 @@ class MetaHelper extends Helper {
 
 		$results = [];
 
-		foreach ($this->meta as $header => $value) {
+		foreach (array_keys($this->meta) as $header) {
 			if (in_array($header, $options['skip'])) {
 				continue;
 			}

--- a/tests/TestCase/View/Helper/MetaHelperTest.php
+++ b/tests/TestCase/View/Helper/MetaHelperTest.php
@@ -655,7 +655,7 @@ class MetaHelperTest extends TestCase {
 		$this->assertStringContainsString('\\u003C', $result);
 		$this->assertStringContainsString('\\u003E', $result);
 		// The closing `</script>` of the actual tag remains exactly once at the end.
-		$this->assertSame(1, substr_count((string) $result, $rawAngleOpen . '/script' . $rawAngleClose));
+		$this->assertSame(1, substr_count((string)$result, $rawAngleOpen . '/script' . $rawAngleClose));
 	}
 
 	/**
@@ -679,7 +679,7 @@ class MetaHelperTest extends TestCase {
 		$this->assertStringNotContainsString($payload, $result);
 		$this->assertStringNotContainsString($rawAngleOpen . 'svg', $result);
 		$this->assertStringContainsString('\\u003C', $result);
-		$this->assertSame(1, substr_count((string) $result, $rawAngleOpen . '/script' . $rawAngleClose));
+		$this->assertSame(1, substr_count((string)$result, $rawAngleOpen . '/script' . $rawAngleClose));
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/MetaHelperTest.php
+++ b/tests/TestCase/View/Helper/MetaHelperTest.php
@@ -655,7 +655,7 @@ class MetaHelperTest extends TestCase {
 		$this->assertStringContainsString('\\u003C', $result);
 		$this->assertStringContainsString('\\u003E', $result);
 		// The closing `</script>` of the actual tag remains exactly once at the end.
-		$this->assertSame(1, substr_count($result, $rawAngleOpen . '/script' . $rawAngleClose));
+		$this->assertSame(1, substr_count((string) $result, $rawAngleOpen . '/script' . $rawAngleClose));
 	}
 
 	/**
@@ -679,7 +679,7 @@ class MetaHelperTest extends TestCase {
 		$this->assertStringNotContainsString($payload, $result);
 		$this->assertStringNotContainsString($rawAngleOpen . 'svg', $result);
 		$this->assertStringContainsString('\\u003C', $result);
-		$this->assertSame(1, substr_count($result, $rawAngleOpen . '/script' . $rawAngleClose));
+		$this->assertSame(1, substr_count((string) $result, $rawAngleOpen . '/script' . $rawAngleClose));
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS == '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.