### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/View/Helper/MetaHelper.php
+++ b/src/View/Helper/MetaHelper.php
@@ -864,7 +864,7 @@ class MetaHelper extends Helper {
 
 		$results = [];
 
-		foreach (array_keys($this->meta) as $header) {
+		foreach ($this->meta as $header => $_) {
 			if (in_array($header, $options['skip'])) {
 				continue;
 			}


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.